### PR TITLE
fix(amf4): update file path in jest tests

### DIFF
--- a/AMF4/src/test/js/conversion.test.js
+++ b/AMF4/src/test/js/conversion.test.js
@@ -13,7 +13,7 @@ test('RAML 1.0 to OAS 2.0', () => {
     const resolver = new amf.Oas20Resolver();
     const renderer = new amf.Oas20Renderer();
 
-    return parser.parseFileAsync("file://src/test/resources/examples/banking-api.raml").then(ramlApi => {
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api.raml')}`).then(ramlApi => {
         const convertedOasApi = resolver.resolve(ramlApi, pipelines.COMPATIBILITY_PIPELINE)
         return renderer.generateString(convertedOasApi).then(result => {
             const expectedResult = fs.readFileSync(path.resolve(__dirname, '../../../resources/expected/converted-banking-api.json'), 'utf8')
@@ -28,7 +28,7 @@ test('OAS 2.0 to RAML 1.0', () => {
     const resolver = new amf.Raml10Resolver();
     const renderer = new amf.Raml10Renderer();
 
-    return parser.parseFileAsync("file://src/test/resources/examples/banking-api.json").then(OasApi => {
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api.json')}`).then(OasApi => {
         const convertedRamlApi = resolver.resolve(OasApi, pipelines.COMPATIBILITY_PIPELINE)
         return renderer.generateString(convertedRamlApi).then(result => {
             const expectedResult = fs.readFileSync(path.resolve(__dirname, '../../../resources/expected/converted-banking-api.raml'), 'utf8')

--- a/AMF4/src/test/js/parsing.test.js
+++ b/AMF4/src/test/js/parsing.test.js
@@ -1,4 +1,5 @@
 const amf = require('amf-client-js');
+const path = require('path');
 
 beforeAll(() => {
     // initializes all AMF plugins, although we only need WebApi Plugin and AMF Core functionality
@@ -13,7 +14,7 @@ test('parse OAS 2.0', () => {
     // A BaseUnit is the return type of any parsing
     // The actual object can be many different things, depending on the content of the source file
     // https://github.com/aml-org/amf/blob/develop/documentation/model.md#baseunit
-    return parser.parseFileAsync('file://src/test/resources/examples/banking-api.json').then(model => {
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api.json')}`).then(model => {
         expect(model).not.toBeNull();
         expect(model).toBeDefined();
     });
@@ -41,7 +42,7 @@ test('parse OAS 2.0 from YAML string', () => {
 test('parse OAS 3.0', () => {
     const parser = new amf.Oas30Parser();
 
-    parser.parseFileAsync('file://src/test/resources/examples/banking-api-oas30.json').then(model => {
+    parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api-oas30.json')}`).then(model => {
         expect(model).not.toBeNull();
         expect(model).toBeDefined();
     });
@@ -51,7 +52,7 @@ test('parse OAS 3.0', () => {
 test('parse RAML 1.0', () => {
     const parser = new amf.Raml10Parser();
 
-    parser.parseFileAsync('file://src/test/resources/examples/banking-api.raml').then(model => {
+    parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api.raml')}`).then(model => {
         expect(model).not.toBeNull();
         expect(model).toBeDefined();
     });
@@ -76,7 +77,7 @@ test('parse RAML 1.0 from string', () => {
 test('parse RAML 0.8', () => {
     const parser = new amf.Raml08Parser();
 
-    return parser.parseFileAsync('file://src/test/resources/examples/banking-api-08.raml').then(model => {
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api-08.raml')}`).then(model => {
         expect(model).not.toBeNull();
         expect(model).toBeDefined();
     });
@@ -101,7 +102,7 @@ test('parse RAML 0.8 from string', () => {
 test('parse AMF Graph', () => {
     const parser = new amf.AmfGraphParser();
 
-    return parser.parseFileAsync('file://src/test/resources/examples/banking-api.jsonld').then(model => {
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api.jsonld')}`).then(model => {
         expect(model).not.toBeNull();
         expect(model).toBeDefined();
     });

--- a/AMF4/src/test/js/payload-validation.test.js
+++ b/AMF4/src/test/js/payload-validation.test.js
@@ -1,4 +1,6 @@
 const amf = require('amf-client-js');
+const path = require('path');
+
 let payloadValidator;
 
 beforeAll(() => {
@@ -7,7 +9,7 @@ beforeAll(() => {
     const parser = new amf.Raml10Parser();
     const resolver = new amf.Raml10Resolver();
 
-    return parser.parseFileAsync('file://src/test/resources/examples/simple-api.raml')
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/simple-api.raml')}`)
         .then(unresolvedModel => {
             const resolvedModel = resolver.resolve(unresolvedModel)
 

--- a/AMF4/src/test/js/resolution.test.js
+++ b/AMF4/src/test/js/resolution.test.js
@@ -1,4 +1,6 @@
 const amf = require('amf-client-js');
+const path = require('path');
+
 const pipelines = amf.ResolutionPipeline;
 
 beforeAll(() => {
@@ -12,7 +14,7 @@ test('Resolve RAML 1.0', () => {
     const resolver = new amf.Raml10Resolver();
     const renderer = new amf.Raml10Renderer(); // to console.log the resolved model
 
-    return parser.parseFileAsync('file://src/test/resources/examples/banking-api.raml').then(unresolvedModel => {
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api.raml')}`).then(unresolvedModel => {
         expect(unresolvedModel).not.toBeNull();
         expect(unresolvedModel).toBeDefined();
 
@@ -30,7 +32,7 @@ test('Resolve OAS 3.0', () => {
     const resolver = new amf.Oas20Resolver()
     const renderer = new amf.Oas30Renderer(); // to console.log the resolved model
 
-    return parser.parseFileAsync('file://src/test/resources/examples/banking-api-oas30.json').then(unresolvedModel => {
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api-oas30.json')}`).then(unresolvedModel => {
         expect(unresolvedModel).not.toBeNull();
         expect(unresolvedModel).toBeDefined();
 

--- a/AMF4/src/test/js/resource-loader.test.js
+++ b/AMF4/src/test/js/resource-loader.test.js
@@ -1,4 +1,5 @@
 const amf = require('amf-client-js');
+const path = require('path');
 
 beforeAll(() => {
     amf.AMF.init();
@@ -14,7 +15,8 @@ class CustomResourceLoader {
 
     // has the logic for fetching in a custom way
     fetch(resource) {
-        const customLogicResult = resource.toString().replace(CustomResourceLoader.CUSTOM_PATTERN, 'file:/');
+        const relativePath = `../../..${resource.toString().replace(CustomResourceLoader.CUSTOM_PATTERN, '')}`;
+        const customLogicResult = `file://${path.resolve(__dirname, relativePath)}`;
         return this.resourceLoader.fetch(customLogicResult);
     }
 
@@ -29,7 +31,7 @@ test('Validate RAML 1.0 with custom resource loader', () => {
     const env = amf.client.DefaultEnvironment.apply().addClientLoader(new CustomResourceLoader());
     const parser = new amf.Raml10Parser(env);
 
-    return parser.parseFileAsync('CustomProtocol/src/test/resources/examples/banking-api.raml')
+    return parser.parseFileAsync('CustomProtocol/resources/examples/banking-api.raml')
         .then(model => {
             expect(model).not.toBeNull();
             expect(model).toBeDefined();

--- a/AMF4/src/test/js/validation.test.js
+++ b/AMF4/src/test/js/validation.test.js
@@ -48,9 +48,6 @@ test('Validate RAML 1.0 with custom validation', () => {
             // }
             return AMF.loadValidationProfile(customValidationProfilePath)
                 .then(customProfile => {
-
-                    console.log(JSON.stringify(customProfile));
-
                     return AMF.validate(model, customProfile, MessageStyles.RAML)
                         .then(report => {
                             console.log(`report.conforms() == ${report.conforms}`)

--- a/AMF4/src/test/js/validation.test.js
+++ b/AMF4/src/test/js/validation.test.js
@@ -1,17 +1,19 @@
 const amf = require('amf-client-js');
+const path = require('path');
+
 const AMF = amf.AMF;
 const ProfileNames = amf.ProfileNames;
 const MessageStyles = amf.MessageStyles;
 
 beforeAll(() => {
+    amf.plugins.features.AMFValidation.register();
     amf.AMF.init();
-
 });
 
 test('Validate RAML 1.0', () => {
     const parser = new amf.Raml10Parser();
 
-    return parser.parseFileAsync('file://src/test/resources/examples/banking-api-error.raml')
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api-error.raml')}`)
         .then(model => {
             expect(model).not.toBeNull();
             expect(model).toBeDefined();
@@ -28,14 +30,26 @@ test('Validate RAML 1.0', () => {
 test('Validate RAML 1.0 with custom validation', () => {
     const parser = new amf.Raml10Parser();
 
-    return parser.parseFileAsync('file://src/test/resources/examples/banking-api-error.raml')
+    return parser.parseFileAsync(`file://${path.resolve(__dirname, '../../../resources/examples/banking-api-error.raml')}`)
         .then(model => {
             expect(model).not.toBeNull();
             expect(model).toBeDefined();
 
+            const customValidationProfilePath = `file://${path.resolve(__dirname, '../../../resources/validation_profile.raml')}`;
+
             // Run RAML custom validations with a validation profile that accepts the previously invalid protocol value
-            return AMF.loadValidationProfile('file://resources/validation_profile.raml')
+            // TODO: Fix
+            // Failed: bc {
+            //   "Hg": null,
+            //   "SJa": true,
+            //   "Xs": "Cannot load a custom validation profile for this",
+            //   "ZX": null,
+            //   "stackdata": [Circular],
+            // }
+            return AMF.loadValidationProfile(customValidationProfilePath)
                 .then(customProfile => {
+
+                    console.log(JSON.stringify(customProfile));
 
                     return AMF.validate(model, customProfile, MessageStyles.RAML)
                         .then(report => {


### PR DESCRIPTION
running `jest` under `AMF4` is broken because file paths are outdated. I've fixed all file paths. 

However, `AMF4/src/test/js/validation.test.js`#'Validate RAML 1.0 with custom validation' is still failing because of the following error
```
● Validate RAML 1.0 with custom validation

    Failed: bc {
      "Hg": null,
      "SJa": true,
      "Xs": "Cannot load a custom validation profile for this",
      "ZX": null,
      "stackdata": [Circular],
    }
```

I think that is beyond file path issue and is a fundamental issue with AMF, please triage and investigate. Thanks! 