### PR TITLE
Test case parsing AML dialects as YAML and JSON

### DIFF
--- a/AMF5/src/test/java/javaPlatform/AMLTest.java
+++ b/AMF5/src/test/java/javaPlatform/AMLTest.java
@@ -1,28 +1,34 @@
 package javaPlatform;
 
-import amf.aml.client.platform.*;
-import amf.aml.client.platform.model.document.Dialect;
-import amf.aml.client.platform.model.domain.DialectDomainElement;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+
+import amf.aml.client.platform.AMLBaseUnitClient;
+import amf.aml.client.platform.AMLConfiguration;
+import amf.aml.client.platform.AMLDialectInstanceResult;
+import amf.aml.client.platform.AMLDialectResult;
+import amf.aml.client.platform.AMLVocabularyResult;
+import amf.aml.client.platform.model.document.Dialect;
+import amf.aml.client.platform.model.domain.DialectDomainElement;
+import amf.core.client.platform.AMFParseResult;
+import amf.core.client.platform.resource.FileResourceLoader;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
 
 public class AMLTest {
 
     private final static String simpleDialectWithVocabulary = "file://src/test/resources/examples/dialect-vocab.yaml";
     private final static String simpleVocabulary = "file://src/test/resources/examples/vocabulary.yaml";
-    private final static String simpleDialect = "file://src/test/resources/examples/dialect.yaml";
+    private final static String simpleDialectYaml = "file://src/test/resources/examples/dialect.yaml";
+    private final static String simpleDialectJson = "file://src/test/resources/examples/dialect.json";
     private final static String simpleDialectInstance = "file://src/test/resources/examples/dialect-instance.yaml";
     private final static String simpleNodeTypeUri = "file://src/test/resources/examples/dialect.yaml#/declarations/Simple";
 
     @Test
     public void parseDialect() throws ExecutionException, InterruptedException {
         final AMLBaseUnitClient client = AMLConfiguration.predefined().baseUnitClient();
-        final AMLDialectResult parseResult = client.parseDialect(simpleDialect).get();
+        final AMLDialectResult parseResult = client.parseDialect(simpleDialectYaml).get();
         assertTrue(parseResult.conforms());
         final Dialect dialect = (Dialect) parseResult.baseUnit();
         final String dialectElementId = dialect.documents().root().encoded().value();
@@ -30,8 +36,23 @@ public class AMLTest {
     }
 
     @Test
+    public void testParsingDialectStringAsJsonAndAsYaml() throws ExecutionException, InterruptedException {
+        final AMLBaseUnitClient client = AMLConfiguration.predefined().baseUnitClient();
+
+        //This one passes successfully
+        final String yaml = new FileResourceLoader().fetch(simpleDialectYaml).get().toString();
+        final AMFParseResult amfParseResultDialectStringYaml = client.parseContent(yaml).get();
+        assertTrue(amfParseResultDialectStringYaml.conforms());
+
+        //This one fails. This is the case that we implemented in CFM.
+        final String json = new FileResourceLoader().fetch(simpleDialectJson).get().toString();
+        final AMFParseResult amfParseResultDialectStringJson = client.parseContent(json).get();
+        assertTrue(amfParseResultDialectStringJson.conforms());
+    }
+
+    @Test
     public void parseDialectInstance() throws ExecutionException, InterruptedException {
-        final AMLBaseUnitClient client = AMLConfiguration.predefined().withDialect(simpleDialect).get().baseUnitClient();
+        final AMLBaseUnitClient client = AMLConfiguration.predefined().withDialect(simpleDialectYaml).get().baseUnitClient();
         final AMLDialectInstanceResult parseResult = client.parseDialectInstance(simpleDialectInstance).get();
         assertTrue(parseResult.conforms());
         final DialectDomainElement instanceElement = parseResult.dialectInstance().encodes();

--- a/AMF5/src/test/resources/examples/dialect.json
+++ b/AMF5/src/test/resources/examples/dialect.json
@@ -1,0 +1,24 @@
+{
+  "$dialect": "Dialect 1.0",
+  "dialect": "SimpleDialect",
+  "version": "1.0",
+  "documents": {
+    "root": {
+      "encodes": "Simple"
+    }
+  },
+  "nodeMappings": {
+    "Simple": {
+      "mapping": {
+        "a": {
+          "unique": true,
+          "range": "string"
+        },
+        "b": {
+          "unique": true,
+          "range": "integer"
+        }
+      }
+    }
+  }
+}

--- a/AMF5/src/test/resources/examples/dialect.yaml
+++ b/AMF5/src/test/resources/examples/dialect.yaml
@@ -1,6 +1,9 @@
 #%Dialect 1.0
 dialect: SimpleDialect
 version: "1.0"
+documents:
+  root:
+    encodes: Simple
 nodeMappings:
   Simple:
     mapping:
@@ -10,6 +13,3 @@ nodeMappings:
       b:
         unique: true
         range: integer
-documents:
-  root:
-    encodes: Simple


### PR DESCRIPTION
Parsing a valid dialect as JSON and as YAML returns different results. With YAML format, the validation passes successfully. With JSON format, the validation fails with an error:

```
Validation report: Network Error: Unexpected status code '301' for resource 'http://a.ml/amf/default_document/Dialect%201.0'
```